### PR TITLE
feat: 新增 ctx.runAndCache 功能

### DIFF
--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -1,66 +1,7 @@
+const runInBackground = require('./ctx/run_in_background');
+const runAndCache = require('./ctx/run_and_cache');
+
 module.exports = {
-  /**
-   * usage:
-   *
-   * 1. 傳入Promise:
-   * const someFunction = async () => { do something here };
-   * ctx.runInBackground(someFunction());
-   *
-   * 2. 傳入function與參數
-   * ctx.runInBackground(async (p1, p2)=> { do something here }, [param1, param2]);
-   */
-  runInBackground(scope, params = []) {
-    const ctx = this;
-    const { coreLogger, utils } = ctx.app;
-    const { is } = utils;
-
-    if (is.promise(scope)) coreLogger.warn('\x1B[33m▉ RunInBackground not recommended use Promise, which may cause the execution order to be different from what is expected!\x1B[0m');
-
-    const onError = (err) => {
-      // eslint-disable-next-line no-param-reassign
-      err.runInBackground = true;
-      ctx.app.emit('onBackgroundError', err, ctx);
-    };
-
-    const dealScope = () => {
-      // 處理傳入的參數，準備pass給function使用
-      let passParams = params;
-      if (!is.nullOrUndefined(params) && !is.array(params)) passParams = [params];
-
-      // 如果傳入的是一個Async function
-      // 將params傳入給scope執行，並等待catch
-      if (is.asyncFunction(scope)) {
-        scope(...passParams).catch(onError);
-        return;
-      }
-
-      // 如果是一般function，直接用try...catch包起來執行
-      if (is.function(scope)) {
-        try {
-          const rs = scope(...passParams);
-          // 如果function執行後是回傳一個promise，也要把錯誤接起來
-          if (is.promise(rs)) {
-            rs.catch(onError);
-          }
-        } catch (err) {
-          onError(err);
-        }
-      }
-    };
-
-    if (!scope) return null;
-
-    // 如果傳入的是Promise，等待catch就好
-    if (is.promise(scope)) {
-      scope.catch(onError);
-      return null;
-    }
-
-    return new Promise((resolve) => {
-      setImmediate(resolve);
-    })
-      .then(() => {
-        dealScope();
-      });
-  },
+  runInBackground,
+  runAndCache,
 };

--- a/app/extend/ctx/run_and_cache.js
+++ b/app/extend/ctx/run_and_cache.js
@@ -1,0 +1,91 @@
+/**
+ * 類似Dataloader，當一個ctx之下有多個程式同時需要執行同一個function時，
+ * 為了避免重複的耗用資源(例如資料庫的讀取)，因此設計成function只被執行一次，
+ * 當function執行完畢後再把資料返回給需要的程式。
+ *
+ * 在同一個ctx之下，執行完畢的資料也會暫時站存在runAndCache裡，後續再呼叫的話
+ * 會優先從cache裡拿取。這一樣是為了減少過度讀取。
+ *
+ * Usage:
+ *
+ * 參數：
+ * key - 用來當作cache的識別
+ * fn - 要被執行的function
+ * params - 要帶入fn的參數
+ *
+ * const rs = await ctx.runAndCache('addTwo', ctx.service.something, [1,2]);
+ */
+
+// 用程式啟動時的timestamp當作Symbol key值
+// 這個Symbol會用來在ctx裡儲存runAndCache的資料
+// 用Symbol+timstamp是為了減少相同property name彼此覆蓋的機率
+const cacheSymbol = Symbol.for(`runAndCache${Date.now()}`);
+
+// 這個function負責等待並監聽資料狀態
+const waitForResponse = (cacheData) => new Promise((resolve) => {
+  const timer = setInterval(() => {
+    if (cacheData.status === 'run') return;
+    clearInterval(timer);
+    resolve(cacheData.data);
+  }, 2);
+});
+
+async function runAndCache(key, fn, params = []) {
+  const ctx = this;
+  const { is } = ctx.app.utils;
+
+  if (!key) throw new Error('[runAndCache] needs a key');
+  if (!is.function(fn)) throw new Error('[runAndCache] invalid function');
+
+  // cacheMap會儲存同一個ctx之下，runAndCache執行的狀態與資料
+  if (!ctx[cacheSymbol]) ctx[cacheSymbol] = new Map();
+  const cacheMap = ctx[cacheSymbol];
+
+  // 處理傳入的參數，準備pass給function使用
+  let passParams = params;
+  if (!is.nullOrUndefined(params) && !is.array(params)) passParams = [params];
+
+  // 把key跟參數串成一個給cacheMap用的key值
+  // 加上參數當成key值是為了確保不同的參數之下不會回傳相同的cache
+  const cacheKey = JSON.stringify({
+    key,
+    params: passParams,
+  });
+  let cacheData = cacheMap.get(cacheKey);
+  if (!cacheData) {
+    cacheData = {
+      status: 'wait',
+      data: null,
+    };
+    cacheMap.set(cacheKey, cacheData);
+  }
+
+  if (cacheData.status !== 'wait') {
+    // 如果已經在執行，就等待結束
+    if (cacheData.status === 'run') {
+      await waitForResponse(cacheData);
+    }
+    // 如果已經執行完畢，直接回傳資料
+    if (cacheData.status === 'complete') return cacheData.data;
+
+    // 如果有錯誤，直接throw
+    if (cacheData.status === 'error') throw cacheData.error;
+  }
+
+  // 執行function
+  // 完畢後修改status並把資料回存到cacheMap
+  cacheData.status = 'run';
+  let rs;
+  try {
+    rs = await fn(...passParams);
+  } catch (e) {
+    cacheData.status = 'error';
+    cacheData.error = e;
+    throw e;
+  }
+  cacheData.data = rs;
+  cacheData.status = 'complete';
+  return rs;
+}
+
+module.exports = runAndCache;

--- a/app/extend/ctx/run_in_background.js
+++ b/app/extend/ctx/run_in_background.js
@@ -1,0 +1,66 @@
+/**
+ * usage:
+ *
+ * 1. 傳入Promise:
+ * const someFunction = async () => { do something here };
+ * ctx.runInBackground(someFunction());
+ *
+ * 2. 傳入function與參數
+ * ctx.runInBackground(async (p1, p2)=> { do something here }, [param1, param2]);
+ */
+function runInBackground(scope, params = []) {
+  const ctx = this;
+  const { coreLogger, utils } = ctx.app;
+  const { is } = utils;
+
+  if (is.promise(scope)) coreLogger.warn('\x1B[33m▉ RunInBackground not recommended use Promise, which may cause the execution order to be different from what is expected!\x1B[0m');
+
+  const onError = (err) => {
+    // eslint-disable-next-line no-param-reassign
+    err.runInBackground = true;
+    ctx.app.emit('onBackgroundError', err, ctx);
+  };
+
+  const dealScope = () => {
+    // 處理傳入的參數，準備pass給function使用
+    let passParams = params;
+    if (!is.nullOrUndefined(params) && !is.array(params)) passParams = [params];
+
+    // 如果傳入的是一個Async function
+    // 將params傳入給scope執行，並等待catch
+    if (is.asyncFunction(scope)) {
+      scope(...passParams).catch(onError);
+      return;
+    }
+
+    // 如果是一般function，直接用try...catch包起來執行
+    if (is.function(scope)) {
+      try {
+        const rs = scope(...passParams);
+        // 如果function執行後是回傳一個promise，也要把錯誤接起來
+        if (is.promise(rs)) {
+          rs.catch(onError);
+        }
+      } catch (err) {
+        onError(err);
+      }
+    }
+  };
+
+  if (!scope) return null;
+
+  // 如果傳入的是Promise，等待catch就好
+  if (is.promise(scope)) {
+    scope.catch(onError);
+    return null;
+  }
+
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  })
+    .then(() => {
+      dealScope();
+    });
+}
+
+module.exports = runInBackground;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mahudas",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
有時不同的service會同時需要呼叫同一個function(或service)，大部分時候是要讀取資料庫，常常就會造成相同的function重複被執行。
Dataloader解決了部分的問題，但Dataloader是專注在針對id或key值進行處理，沒辦法囊括所有狀況。
所以想說在Mahudas裡新增 ctx.runAndCache，讓一個function只會被讀取一次，並且已經執行過的結果會被暫時cache住 (同一個ctx階段時)，用來減少資料庫的負擔。
